### PR TITLE
Eliminate any dynamically allocated memory and decrease ledger lines

### DIFF
--- a/inc/instrument.hpp
+++ b/inc/instrument.hpp
@@ -10,14 +10,15 @@
 #include <string>
 #include <mutex>
 #include <random>
+#include <memory>
 
 // Structs to store Instrument Data (Passed from Instrument classes to Instrument Base)
 struct InstrumentData
 {
     // Musical Shared Data
-    AnalysisMatrix* pitches_;
-    AnalysisMatrix* rhythms_;
-    AnalysisMatrix* articulations_;
+    std::shared_ptr<AnalysisMatrix> pitches_;
+    std::shared_ptr<AnalysisMatrix> rhythms_;
+    std::shared_ptr<AnalysisMatrix>  articulations_;
     TimeSignature ts_;
 };
 
@@ -50,9 +51,9 @@ private:
 protected:
 
     // All Inherited Instruments can use the Analysis Matrices and dynamics rows
-    AnalysisMatrix *pitches_;
-    AnalysisMatrix *rhythms_;
-    AnalysisMatrix *articulations_;
+    std::shared_ptr<AnalysisMatrix> pitches_;
+    std::shared_ptr<AnalysisMatrix> rhythms_;
+    std::shared_ptr<AnalysisMatrix> articulations_;
     TimeSignature ts_;
 
     // Everything can access the pitch, articulation and dynamic mappings

--- a/inc/instrumentFactory.hpp
+++ b/inc/instrumentFactory.hpp
@@ -26,7 +26,7 @@ class InstrumentFactory {
 
 public:
 
-    InstrumentFactory(AnalysisMatrix *pitches, AnalysisMatrix *rhythms, AnalysisMatrix *articulations, TimeSignature ts, BoulezData boulezMutex);
+    InstrumentFactory(std::shared_ptr<AnalysisMatrix> pitches, std::shared_ptr<AnalysisMatrix> rhythms, std::shared_ptr<AnalysisMatrix> articulations, TimeSignature ts, BoulezData boulezMutex);
     ~InstrumentFactory() = default;
 
     /**
@@ -37,9 +37,9 @@ public:
      * @param rows The rows for the whole piece. Doesn't need to be 12 rows long
      * @param dynamics The dynamics for each row. 
      * @param num Number of this instrument. Allows for Violin 1 and Violin 2 to have different parts. 
-     * @return SingleClefInstrument* 
+     * @return SingleClefInstrument* (shared)
      */
-    SingleClefInstrument *createInstrument(std::string instrumentName, std::vector<Row> rows, std::vector<short> dynamics, int num);
+    std::shared_ptr<SingleClefInstrument> createInstrument(std::string instrumentName, std::vector<Row> rows, std::vector<short> dynamics, int num);
     
     /**
      * @brief Create a Instrument object. This is only for Piano and Harp
@@ -49,9 +49,9 @@ public:
      * @param lhRows  Rows for left hand
      * @param dynamics Dynamics for each row. Dynamics are the same in each hand
      * @param num To allow for multiple pianos/harps. 
-     * @return MultiClefInstrument* 
+     * @return MultiClefInstrument* (shared)
      */
-    MultiClefInstrument *createInstrument(std::string instrumentName, std::vector<Row> rhRows, std::vector<Row> lhRows, std::vector<short> dynamics, int num);
+    std::shared_ptr<MultiClefInstrument> createInstrument(std::string instrumentName, std::vector<Row> rhRows, std::vector<Row> lhRows, std::vector<short> dynamics, int num);
 };
 
 #endif // INSTRUMENT_FACTORY_HPP_INCUDED

--- a/inc/serialismGenerator.hpp
+++ b/inc/serialismGenerator.hpp
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <unordered_map>
 #include <tuple>
+#include <memory>
 
 #include "instrumentFactory.hpp"
 #include "timeSignature.hpp"
@@ -74,13 +75,13 @@ class SerialismGenerator
     std::string outputFilename_;
 
     // Matrices (dynamically managed)
-    AnalysisMatrix* pitches_;
-    AnalysisMatrix* rhythms_;
-    AnalysisMatrix* articulations_;
+    std::shared_ptr<AnalysisMatrix> pitches_;
+    std::shared_ptr<AnalysisMatrix> rhythms_;
+    std::shared_ptr<AnalysisMatrix> articulations_;
 
     // Factory and Instrument vector
-    InstrumentFactory* factory_;
-    std::vector<Instrument*> instruments_;
+    std::shared_ptr<InstrumentFactory> factory_;
+    std::vector<std::shared_ptr<Instrument>> instruments_;
     
     // Instrument names holds the name of each instrument and the number of them
     // Used to calculate Display Name in instrument objects
@@ -162,8 +163,8 @@ class SerialismGenerator
     SerialismGenerator(std::string inputfile, std::string outputFilename);
     
     // Clean up Analysis Matrices, Instruments and Factory
-    ~SerialismGenerator();
-    
+    ~SerialismGenerator() = default;
+
     /**
      * @brief Runs the Total Serial Generator process from end to end. 
      * 

--- a/src/instrumentDefinitions.cpp
+++ b/src/instrumentDefinitions.cpp
@@ -3,7 +3,7 @@
 using namespace std;
 
 Violin::Violin(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) : 
-SingleClefInstrument(data, boulez, {rows, "Violin", "violin", dynamics, "treble", "c''",num}, {Note("g", 0), Note("a", 4)}){};
+SingleClefInstrument(data, boulez, {rows, "Violin", "violin", dynamics, "treble", "c'",num}, {Note("g", 0), Note("a", 4)}){};
 
 Viola::Viola(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) : 
 SingleClefInstrument(data, boulez, {rows, "Viola", "viola", dynamics, "alto", "c'",num}, {Note("c", 0), Note("g", 2)}){};
@@ -15,7 +15,7 @@ Bass::Bass(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, i
 SingleClefInstrument(data, boulez, {rows, "String Bass", "bass", dynamics, "bass", "c",num}, {Note("e", -1), Note("d", 3)}){};
 
 AltoSax::AltoSax(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) :
-SingleClefInstrument(data, boulez, {rows, "Alto Saxophone", "altosax", dynamics, "treble", "c''", num}, {Note("cs", 0), Note("af", 2)}){};
+SingleClefInstrument(data, boulez, {rows, "Alto Saxophone", "altosax", dynamics, "treble", "c'", num}, {Note("cs", 0), Note("af", 2)}){};
 
 TenorSax::TenorSax(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) : 
 SingleClefInstrument(data, boulez, {rows, "Tenor Saxophone", "tenorsax", dynamics, "treble", "c'", num}, {Note("af", -1), Note("e", 2)}){};
@@ -24,28 +24,28 @@ BariSax::BariSax(InstrumentData data, std::vector<Row> rows, vector<short> dynam
 SingleClefInstrument(data, boulez, {rows, "Bari Saxophone", "barisax", dynamics, "bass", "c", num}, {Note("cs", 0), Note("af", 2)}){};
 
 Oboe::Oboe(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) : 
-SingleClefInstrument(data, boulez, {rows, "Oboe", "oboe", dynamics, "treble", "c''", num}, {Note("bf", 0), Note("g", 3)}){};
+SingleClefInstrument(data, boulez, {rows, "Oboe", "oboe", dynamics, "treble", "c'", num}, {Note("bf", 0), Note("g", 3)}){};
 
 Bassoon::Bassoon(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) : 
-SingleClefInstrument(data, boulez, {rows, "Bassoon", "bassoon", dynamics, "bass", "c", num}, {Note("bf", -2), Note("g", 2)}){};
+SingleClefInstrument(data, boulez, {rows, "Bassoon", "bassoon", dynamics, "bass", "c,", num}, {Note("bf", -2), Note("g", 2)}){};
 
 Clarinet::Clarinet(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) : 
-SingleClefInstrument(data, boulez, {rows, "Clarinet", "clarinet", dynamics, "treble", "c''", num}, {Note("d", 0), Note("bf", 3)}){};
+SingleClefInstrument(data, boulez, {rows, "Clarinet", "clarinet", dynamics, "treble", "c'", num}, {Note("d", 0), Note("bf", 3)}){};
 
 Piccolo::Piccolo(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) : 
 SingleClefInstrument(data, boulez, {rows, "Piccolo", "piccolo", dynamics, "treble", "c''", num}, {Note("d", 1), Note("c", 4)}){};
 
 Flute::Flute(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) : 
-SingleClefInstrument(data, boulez, {rows, "Flute", "flute", dynamics, "treble", "c''", num}, {Note("c", 1), Note("f", 3)}){};
+SingleClefInstrument(data, boulez, {rows, "Flute", "flute", dynamics, "treble", "c'", num}, {Note("c", 1), Note("f", 3)}){};
 
 Trombone::Trombone(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) :
 SingleClefInstrument(data, boulez, {rows, "Trombone", "trombone", dynamics, "bass", "c",num}, {Note("e", -1), Note("f", 2)}){};
 
 Trumpet::Trumpet(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) :
-SingleClefInstrument(data, boulez, {rows, "Trumpet", "trumpet", dynamics, "treble", "c''",num}, {Note("e", 0), Note("d", 3)}){};
+SingleClefInstrument(data, boulez, {rows, "Trumpet", "trumpet", dynamics, "treble", "c'",num}, {Note("e", 0), Note("d", 3)}){};
 
 FrenchHorn::FrenchHorn(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) :
-SingleClefInstrument(data, boulez, {rows, "French Horn", "frenchhorn", dynamics, "bass", "c",num}, {Note("a", -2), Note("f", 2)}){};
+SingleClefInstrument(data, boulez, {rows, "French Horn", "frenchhorn", dynamics, "bass", "c,",num}, {Note("a", -2), Note("f", 2)}){};
 
 Tuba::Tuba(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) :
-SingleClefInstrument(data, boulez, {rows, "Tuba", "tuba", dynamics, "bass", "c",num}, {Note("d", -2), Note("f", 1)}){};
+SingleClefInstrument(data, boulez, {rows, "Tuba", "tuba", dynamics, "bass", "c,",num}, {Note("d", -2), Note("f", 1)}){};

--- a/src/instrumentFactory.cpp
+++ b/src/instrumentFactory.cpp
@@ -1,52 +1,52 @@
 #include "instrumentFactory.hpp"
 
-InstrumentFactory::InstrumentFactory(AnalysisMatrix *pitches, AnalysisMatrix *rhythms, AnalysisMatrix *articulations, TimeSignature ts, BoulezData boulez) : 
+InstrumentFactory::InstrumentFactory(std::shared_ptr<AnalysisMatrix> pitches, std::shared_ptr<AnalysisMatrix> rhythms, std::shared_ptr<AnalysisMatrix> articulations, TimeSignature ts, BoulezData boulez) : 
     data_{pitches, rhythms, articulations, ts}, boulez_{boulez}{
 }
 
-SingleClefInstrument* InstrumentFactory::createInstrument(std::string name, std::vector<Row> rows, std::vector<short> dynamics, int num){
+std::shared_ptr<SingleClefInstrument> InstrumentFactory::createInstrument(std::string name, std::vector<Row> rows, std::vector<short> dynamics, int num){
     if (name == "violin"){
-        return new Violin(data_, rows, dynamics, num, boulez_);
+        return std::make_shared<Violin>(data_, rows, dynamics, num, boulez_);
     } else if (name == "viola") {
-        return new Viola(data_, rows, dynamics, num, boulez_);
+        return std::make_shared<Viola>(data_, rows, dynamics, num, boulez_);
     } else if (name == "cello"){
-        return new Cello(data_, rows, dynamics, num, boulez_);
+        return std::make_shared<Cello>(data_, rows, dynamics, num, boulez_);
     } else if (name == "bass") {
-        return new Bass(data_, rows, dynamics, num, boulez_);
+        return std::make_shared<Bass>(data_, rows, dynamics, num, boulez_);
     } else if (name == "altosax") {
-        return new AltoSax(data_, rows, dynamics, num, boulez_);
+        return std::make_shared<AltoSax>(data_, rows, dynamics, num, boulez_);
     } else if (name == "tenorsax") {
-        return new TenorSax(data_, rows, dynamics, num, boulez_);
+        return std::make_shared<TenorSax>(data_, rows, dynamics, num, boulez_);
     } else if (name == "barisax") {
-        return new BariSax(data_, rows, dynamics, num, boulez_);
+        return std::make_shared<BariSax>(data_, rows, dynamics, num, boulez_);
     } else if (name == "oboe") {
-        return new Oboe(data_, rows, dynamics, num, boulez_);
+        return std::make_shared<Oboe>(data_, rows, dynamics, num, boulez_);
     } else if (name == "bassoon") {
-        return new Bassoon(data_, rows, dynamics, num, boulez_);
+        return std::make_shared<Bassoon>(data_, rows, dynamics, num, boulez_);
     } else if (name == "clarinet") {
-        return new Clarinet(data_, rows, dynamics, num, boulez_);
+        return std::make_shared<Clarinet>(data_, rows, dynamics, num, boulez_);
     } else if (name == "piccolo") {
-        return new Piccolo(data_, rows, dynamics, num, boulez_);
+        return std::make_shared<Piccolo>(data_, rows, dynamics, num, boulez_);
     } else if (name == "trombone") {
-        return new Trombone(data_, rows, dynamics, num, boulez_);
+        return std::make_shared<Trombone>(data_, rows, dynamics, num, boulez_);
     } else if (name == "trumpet") {
-        return new Trumpet(data_, rows, dynamics, num, boulez_);
+        return std::make_shared<Trumpet>(data_, rows, dynamics, num, boulez_);
     } else if (name == "frenchhorn") {
-        return new FrenchHorn(data_, rows, dynamics, num, boulez_);
+        return std::make_shared<FrenchHorn>(data_, rows, dynamics, num, boulez_);
     } else if (name == "tuba") {
-        return new Tuba(data_, rows, dynamics, num, boulez_);
+        return std::make_shared<Tuba>(data_, rows, dynamics, num, boulez_);
     } else if (name == "flute") {
-        return new Flute(data_, rows, dynamics, num, boulez_);
+        return std::make_shared<Flute>(data_, rows, dynamics, num, boulez_);
     } else {
         std::cerr << "Invalid Instrument" << std::endl;
         return nullptr;
     }
 }
 
-MultiClefInstrument* InstrumentFactory::createInstrument(std::string name, std::vector<Row> rhRows, std::vector<Row> lhRows, std::vector<short> dynamics, int num){
+std::shared_ptr<MultiClefInstrument> InstrumentFactory::createInstrument(std::string name, std::vector<Row> rhRows, std::vector<Row> lhRows, std::vector<short> dynamics, int num){
     if (name == "harp"){
-        return new Harp(data_, rhRows, lhRows, dynamics, num, boulez_);
+        return std::make_shared<Harp>(data_, rhRows, lhRows, dynamics, num, boulez_);
     } else {
-        return new Piano(data_, rhRows, lhRows, dynamics, num, boulez_);
+        return std::make_shared<Piano>(data_, rhRows, lhRows, dynamics, num, boulez_);
     }
 }


### PR DESCRIPTION
There should be no more `new` keywords to eliminate any dynamically managed memory. I also decreased the clefs by one octave since the C is the lowest note in the Lilypond defined octave. This decreases ledger lines significantly and should make music easier to read. 