### PR TITLE
Feature/better instrument names

### DIFF
--- a/inc/instrument.hpp
+++ b/inc/instrument.hpp
@@ -103,7 +103,7 @@ public:
      *
      * @return std::string
      */
-    virtual std::string instrumentScoreBox() = 0;
+    virtual std::string instrumentScoreBox(bool specificPart) = 0;
 
     // Utility Functions
 
@@ -156,13 +156,6 @@ public:
      */
     virtual int getNum() = 0;
 
-    // /**
-    //  * @brief Makesthe individual part
-    //  * 
-    //  * @param filename Filename ot write to. 
-    //  */
-    // virtual void makePart(std::string filename) = 0;
-    
     /**
      * @brief Gets the header information for each part
      * 

--- a/inc/instrument.hpp
+++ b/inc/instrument.hpp
@@ -11,6 +11,8 @@
 #include <mutex>
 #include <random>
 #include <memory>
+#include <iostream>
+#include <fstream>
 
 // Structs to store Instrument Data (Passed from Instrument classes to Instrument Base)
 struct InstrumentData
@@ -101,7 +103,7 @@ public:
      *
      * @return std::string
      */
-    virtual std::string scoreBox() = 0;
+    virtual std::string instrumentScoreBox() = 0;
 
     // Utility Functions
 
@@ -154,12 +156,29 @@ public:
      */
     virtual int getNum() = 0;
 
+    // /**
+    //  * @brief Makesthe individual part
+    //  * 
+    //  * @param filename Filename ot write to. 
+    //  */
+    // virtual void makePart(std::string filename) = 0;
+    
     /**
-     * @brief Makesthe individual part
+     * @brief Gets the header information for each part
      * 
-     * @param filename Filename ot write to. 
+     * @return std::string String with the header information
      */
-    virtual void makePart(std::string filename) = 0;
+    std::string header(std::string title, std::string composer);
+    
+    /**
+     * @brief Makes the part for the instrument
+     * 
+     * @param filename filename to write to
+     */
+    void makePart(std::string filename, std::string title, std::string composer);
+
 };
+
+
 
 #endif // INSTRUMENT_HPP_INCLUDED

--- a/inc/multiClef.hpp
+++ b/inc/multiClef.hpp
@@ -21,7 +21,8 @@ struct MultiClefData{
     std::vector<Row> lhRows_;
     std::vector<short> dynamic_;
     std::string displayName_;
-    std::string variableName_; 
+    std::string variableName_;
+    std::string shortName_;
     int num_;
 };
 
@@ -37,9 +38,10 @@ class MultiClefInstrument : public Instrument
     std::vector<short> dynamics_;
     std::string variableName_;
     std::string displayName_;
+    std::string shortName_;
     int num_;
 
-  public:
+public:
     MultiClefInstrument(InstrumentData data, BoulezData boulez, MultiClefData MCdata, Range r);
     virtual ~MultiClefInstrument();
 
@@ -64,7 +66,7 @@ class MultiClefInstrument : public Instrument
      * 
      * @return std::string Score box code. 
      */
-    std::string instrumentScoreBox();
+    std::string instrumentScoreBox(bool specificPart);
 
         /**
      * @brief Get the Name object

--- a/inc/multiClef.hpp
+++ b/inc/multiClef.hpp
@@ -64,7 +64,7 @@ class MultiClefInstrument : public Instrument
      * 
      * @return std::string Score box code. 
      */
-    std::string scoreBox();
+    std::string instrumentScoreBox();
 
         /**
      * @brief Get the Name object
@@ -79,12 +79,12 @@ class MultiClefInstrument : public Instrument
      */
     int getNum();
 
-    /**
-     * @brief Makes the individual part
-     *
-     * @param filename Filename to write to;
-     */
-    void makePart(std::string filename);
+    // /**
+    //  * @brief Makes the individual part
+    //  *
+    //  * @param filename Filename to write to;
+    //  */
+    // void makePart(std::string filename);
 };
 
 #endif // MULTI_CLEF_HPP_INCLUDED

--- a/inc/serialismGenerator.hpp
+++ b/inc/serialismGenerator.hpp
@@ -122,6 +122,13 @@ class SerialismGenerator
     std::string header() const;
 
     /**
+     * @brief Creates the code for the global and paper blocks
+     * This is needd to get the tempo on the correct line and adjust the paper size accordingly. 
+     * @return std::string global and paper box settings string. 
+     */
+    std::string globalPaperBox() const;
+
+    /**
      * @brief Returns the "Score box" for the piece. 
      * The score box in lilypond is analogous to the main function in C++
      * This is the driver code that lets the staves get called and added correcly. 

--- a/inc/serialismGenerator.hpp
+++ b/inc/serialismGenerator.hpp
@@ -25,11 +25,6 @@
  * instruments and complete the entire score. There is only one instance of a
  * SerialismGenerator created. 
  * 
- * Memory: The Serialism Generator class owns pointers to 
- * 3 analysis Matrices, all instruments and the instrument Factory. 
- * It also has the instances of the mutex and distributions shared between
- * all the instruments.  
- * 
  */
 class SerialismGenerator
 {
@@ -126,7 +121,7 @@ class SerialismGenerator
      * This is needd to get the tempo on the correct line and adjust the paper size accordingly. 
      * @return std::string global and paper box settings string. 
      */
-    std::string globalPaperBox() const;
+    std::string definitionHeader() const;
 
     /**
      * @brief Returns the "Score box" for the piece. 
@@ -135,7 +130,7 @@ class SerialismGenerator
      * 
      * @return std::string 
      */
-    std::string scoreBox(bool parts=false);
+    std::string scoreBox();
 
     // Utility Functions
 

--- a/inc/singleClef.hpp
+++ b/inc/singleClef.hpp
@@ -66,7 +66,7 @@ class SingleClefInstrument : public Instrument
      * 
      * @return std::string The score box for the instrument. 
      */
-    std::string scoreBox();
+    std::string instrumentScoreBox();
     
     /**
      * @brief Get the Name object
@@ -81,12 +81,12 @@ class SingleClefInstrument : public Instrument
      */
     int getNum();
 
-    /**
-     * @brief Makes the individual part score box file
-     * 
-     * @param filename Filename to write to
-     */
-    void makePart(std::string filename);
+    // /**
+    //  * @brief Makes the individual part score box file
+    //  * 
+    //  * @param filename Filename to write to
+    //  */
+    // void makePart(std::string filename);
 };
 
 #endif

--- a/inc/singleClef.hpp
+++ b/inc/singleClef.hpp
@@ -14,6 +14,7 @@
  * rows_: Rows for the instrument
  * displayName_: Name for the score
  * variableName_: Name for the variable in the score. Cannot have whitespace
+ * shortName_: Abbreviated name for the instrument
  * dynamicsRow_: Rows for the dynamics. 
  * clef_: Clef for staff header. Values should be 'treble', 'alto' or 'bass' 
  * octave_: Octave for lilypond to start in.  Often in the center of the instrument range
@@ -25,6 +26,7 @@ struct SingleClefData
     std::vector<Row> rows_;
     std::string displayName_;
     std::string variableName_;
+    std::string shortName_;
     std::vector<short> dynamicsRow_;
     std::string clef_;
     std::string octave_;
@@ -38,6 +40,7 @@ class SingleClefInstrument : public Instrument
     std::vector<Row> rows_;
     std::string displayName_;
     std::string variableName_;
+    std::string shortName_;
     std::vector<short> dynamicsRow_;
     std::string clef_;
     std::string octave_;
@@ -66,7 +69,7 @@ class SingleClefInstrument : public Instrument
      * 
      * @return std::string The score box for the instrument. 
      */
-    std::string instrumentScoreBox();
+    std::string instrumentScoreBox(bool specificPart);
     
     /**
      * @brief Get the Name object

--- a/score.sh
+++ b/score.sh
@@ -29,10 +29,9 @@ else
             cd score-random_score_seed_$seed;
             lilypond -f pdf -l NONE *.ly
             cd ..
-            pwd;
             finalFile=score-random_score_seed_$seed/random_score_seed_$seed.pdf;
         else #No Arguments
-            build/TotalSerialism; # extract parts? 
+            build/TotalSerialism;
             lilypond -f pdf -l NONE random_score.ly; 
             finalFile=random_score.pdf
         fi

--- a/score.sh
+++ b/score.sh
@@ -32,7 +32,7 @@ else
             pwd;
             finalFile=score-random_score_seed_$seed/random_score_seed_$seed.pdf;
         else #No Arguments
-            build/TotalSerialism;
+            build/TotalSerialism; # extract parts? 
             lilypond -f pdf -l NONE random_score.ly; 
             finalFile=random_score.pdf
         fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,4 @@
+rm -rf build
 mkdir build;
 cd build;
 cmake ..;

--- a/src/instrument.cpp
+++ b/src/instrument.cpp
@@ -209,7 +209,8 @@ void Instrument::makePart(std::string filename, std::string title, std::string c
     fileContents += "\\include \"definitions.ily\"\n\n";
     fileContents += header(title, composer);
     fileContents += "\\score {\n";
-    fileContents += instrumentScoreBox();
+    fileContents += instrumentScoreBox(true);
+    fileContents += "\t\\layout {\n\tindent = 2 \\cm\n\tshort-indent = 1\\cm\n\t}\n";
     fileContents += "}\n";
     std::ofstream out(filename);
     out << fileContents << endl;

--- a/src/instrument.cpp
+++ b/src/instrument.cpp
@@ -191,4 +191,26 @@ std::string Instrument::boulezJitter(){
     return "";
 }
 
+std::string Instrument::header(std::string title, std::string composer){
+    std::string header = "\\header {\n\t title = \"";
+    header += title;
+    header += "\"\n\tsubtitile = \"Algorithmic Composition\"";
+    // header += subtitile;
+    header += "\n\tinstrument = \"";
+    header += getName() + " " + to_string(getNum()) + "\"";
+    header += "\n\tcomposer = \"";
+    header += composer;
+    header += "\"\n\ttagline = ##f}\n\n";
+    return header;
+}
 
+void Instrument::makePart(std::string filename, std::string title, std::string composer){
+    string fileContents = "\\version \"2.24.1\"\n\\language \"english\"\n\n";
+    fileContents += "\\include \"definitions.ily\"\n\n";
+    fileContents += header(title, composer);
+    fileContents += "\\score {\n";
+    fileContents += instrumentScoreBox();
+    fileContents += "}\n";
+    std::ofstream out(filename);
+    out << fileContents << endl;
+}

--- a/src/instrumentDefinitions.cpp
+++ b/src/instrumentDefinitions.cpp
@@ -3,49 +3,49 @@
 using namespace std;
 
 Violin::Violin(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) : 
-SingleClefInstrument(data, boulez, {rows, "Violin", "violin", dynamics, "treble", "c'",num}, {Note("g", 0), Note("a", 4)}){};
+SingleClefInstrument(data, boulez, {rows, "Violin", "violin", "vln", dynamics, "treble", "c'",num}, {Note("g", 0), Note("a", 4)}){};
 
 Viola::Viola(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) : 
-SingleClefInstrument(data, boulez, {rows, "Viola", "viola", dynamics, "alto", "c'",num}, {Note("c", 0), Note("g", 2)}){};
+SingleClefInstrument(data, boulez, {rows, "Viola", "viola", "vla", dynamics, "alto", "c'",num}, {Note("c", 0), Note("g", 2)}){};
 
 Cello::Cello(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) : 
-SingleClefInstrument(data, boulez, {rows, "Cello", "cello", dynamics, "bass", "c",num}, {Note("c", -1), Note("e", 3)}){};
+SingleClefInstrument(data, boulez, {rows, "Cello", "cello", "vlc",  dynamics, "bass", "c",num}, {Note("c", -1), Note("e", 3)}){};
 
 Bass::Bass(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) : 
-SingleClefInstrument(data, boulez, {rows, "String Bass", "bass", dynamics, "bass", "c",num}, {Note("e", -1), Note("d", 3)}){};
+SingleClefInstrument(data, boulez, {rows, "String Bass", "bass", "cb", dynamics, "bass", "c",num}, {Note("e", -1), Note("d", 3)}){};
 
 AltoSax::AltoSax(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) :
-SingleClefInstrument(data, boulez, {rows, "Alto Saxophone", "altosax", dynamics, "treble", "c'", num}, {Note("cs", 0), Note("af", 2)}){};
+SingleClefInstrument(data, boulez, {rows, "Alto Saxophone", "altosax", "a sax", dynamics, "treble", "c'", num}, {Note("cs", 0), Note("af", 2)}){};
 
 TenorSax::TenorSax(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) : 
-SingleClefInstrument(data, boulez, {rows, "Tenor Saxophone", "tenorsax", dynamics, "treble", "c'", num}, {Note("af", -1), Note("e", 2)}){};
+SingleClefInstrument(data, boulez, {rows, "Tenor Saxophone", "tenorsax", "t sax", dynamics, "treble", "c'", num}, {Note("af", -1), Note("e", 2)}){};
 
 BariSax::BariSax(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) : 
-SingleClefInstrument(data, boulez, {rows, "Bari Saxophone", "barisax", dynamics, "bass", "c", num}, {Note("cs", 0), Note("af", 2)}){};
+SingleClefInstrument(data, boulez, {rows, "Bari Saxophone", "barisax", "b sax", dynamics, "bass", "c", num}, {Note("cs", 0), Note("af", 2)}){};
 
 Oboe::Oboe(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) : 
-SingleClefInstrument(data, boulez, {rows, "Oboe", "oboe", dynamics, "treble", "c'", num}, {Note("bf", 0), Note("g", 3)}){};
+SingleClefInstrument(data, boulez, {rows, "Oboe", "oboe", "ob", dynamics, "treble", "c'", num}, {Note("bf", 0), Note("g", 3)}){};
 
 Bassoon::Bassoon(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) : 
-SingleClefInstrument(data, boulez, {rows, "Bassoon", "bassoon", dynamics, "bass", "c,", num}, {Note("bf", -2), Note("g", 2)}){};
+SingleClefInstrument(data, boulez, {rows, "Bassoon", "bassoon", "fag", dynamics, "bass", "c,", num}, {Note("bf", -2), Note("g", 2)}){};
 
 Clarinet::Clarinet(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) : 
-SingleClefInstrument(data, boulez, {rows, "Clarinet", "clarinet", dynamics, "treble", "c'", num}, {Note("d", 0), Note("bf", 3)}){};
+SingleClefInstrument(data, boulez, {rows, "Clarinet", "clarinet", "cl", dynamics, "treble", "c'", num}, {Note("d", 0), Note("bf", 3)}){};
 
 Piccolo::Piccolo(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) : 
-SingleClefInstrument(data, boulez, {rows, "Piccolo", "piccolo", dynamics, "treble", "c''", num}, {Note("d", 1), Note("c", 4)}){};
+SingleClefInstrument(data, boulez, {rows, "Piccolo", "piccolo", "picc", dynamics, "treble", "c''", num}, {Note("d", 1), Note("c", 4)}){};
 
 Flute::Flute(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) : 
-SingleClefInstrument(data, boulez, {rows, "Flute", "flute", dynamics, "treble", "c'", num}, {Note("c", 1), Note("f", 3)}){};
+SingleClefInstrument(data, boulez, {rows, "Flute", "flute", "fl", dynamics, "treble", "c'", num}, {Note("c", 1), Note("f", 3)}){};
 
 Trombone::Trombone(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) :
-SingleClefInstrument(data, boulez, {rows, "Trombone", "trombone", dynamics, "bass", "c",num}, {Note("e", -1), Note("f", 2)}){};
+SingleClefInstrument(data, boulez, {rows, "Trombone", "trombone", "tb", dynamics, "bass", "c",num}, {Note("e", -1), Note("f", 2)}){};
 
 Trumpet::Trumpet(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) :
-SingleClefInstrument(data, boulez, {rows, "Trumpet", "trumpet", dynamics, "treble", "c'",num}, {Note("e", 0), Note("d", 3)}){};
+SingleClefInstrument(data, boulez, {rows, "Trumpet", "trumpet", "tr", dynamics, "treble", "c'",num}, {Note("e", 0), Note("d", 3)}){};
 
 FrenchHorn::FrenchHorn(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) :
-SingleClefInstrument(data, boulez, {rows, "French Horn", "frenchhorn", dynamics, "bass", "c,",num}, {Note("a", -2), Note("f", 2)}){};
+SingleClefInstrument(data, boulez, {rows, "French Horn", "frenchhorn", "cor", dynamics, "bass", "c,",num}, {Note("a", -2), Note("f", 2)}){};
 
 Tuba::Tuba(InstrumentData data, std::vector<Row> rows, vector<short> dynamics, int num, BoulezData boulez) :
-SingleClefInstrument(data, boulez, {rows, "Tuba", "tuba", dynamics, "bass", "c,",num}, {Note("d", -2), Note("f", 1)}){};
+SingleClefInstrument(data, boulez, {rows, "Tuba", "tuba", "tb", dynamics, "bass", "c,",num}, {Note("d", -2), Note("f", 1)}){};

--- a/src/multiClef.cpp
+++ b/src/multiClef.cpp
@@ -77,7 +77,7 @@ string MultiClefInstrument::staffHeader(){
 }
 
 // Variable names will look like rightXX_hand 
-string MultiClefInstrument::scoreBox() {
+string MultiClefInstrument::instrumentScoreBox() {
     string scoreBox = "\t\\new PianoStaff \\with {instrumentName = \"";
     scoreBox += displayName_ +" "+ to_string(num_) + "\"} {\n\t\t<<";
     scoreBox += "\n\t\t\\new Staff {\\" + variableName_ + "_right"+ " }";
@@ -93,12 +93,12 @@ int MultiClefInstrument::getNum(){
     return num_;
 }
 
-void MultiClefInstrument::makePart(std::string filename){
-    string fileContents = "\\version \"2.24.1\"\n\\language \"english\"\n\n";
-    fileContents += "\\include \"definitions.ily\"\n\n";
-    fileContents += "\\score {\n";
-    fileContents += scoreBox();
-    fileContents += "}\n";
-    std::ofstream out(filename);
-    out << fileContents << endl;
-}
+// void MultiClefInstrument::makePart(std::string filename){
+//     string fileContents = "\\version \"2.24.1\"\n\\language \"english\"\n\n";
+//     fileContents += "\\include \"definitions.ily\"\n\n";
+//     fileContents += "\\score {\n";
+//     fileContents += scoreBox();
+//     fileContents += "}\n";
+//     std::ofstream out(filename);
+//     out << fileContents << endl;
+// }

--- a/src/multiClef.cpp
+++ b/src/multiClef.cpp
@@ -8,6 +8,7 @@ MultiClefInstrument::MultiClefInstrument(InstrumentData data, BoulezData boulez,
                     dynamics_{MCdata.dynamic_},
                     displayName_{MCdata.displayName_},
                     variableName_{MCdata.variableName_},
+                    shortName_{MCdata.shortName_},
                     num_{MCdata.num_}{
                         for (size_t i = 0; i < num_ - 1; ++i){
                             variableName_ += "X";
@@ -77,9 +78,14 @@ string MultiClefInstrument::staffHeader(){
 }
 
 // Variable names will look like rightXX_hand 
-string MultiClefInstrument::instrumentScoreBox() {
+string MultiClefInstrument::instrumentScoreBox(bool specificPart) {
     string scoreBox = "\t\\new PianoStaff \\with {instrumentName = \"";
-    scoreBox += displayName_ +" "+ to_string(num_) + "\"} {\n\t\t<<";
+    scoreBox += displayName_ + " " + to_string(num_) + "\"";
+    if (!specificPart){
+        scoreBox += " shortInstrumentName = \"";
+        scoreBox += shortName_ + " " + to_string(num_) + "\"";     
+    }
+    scoreBox += "} {\n\t\t<<";
     scoreBox += "\n\t\t\\new Staff {\\" + variableName_ + "_right"+ " }";
     scoreBox += "\n\t\t\\new Staff {\\" + variableName_ + "_left" + " }";
     scoreBox += " \n\t\t>>\n\t}\n";
@@ -92,13 +98,3 @@ std::string MultiClefInstrument::getName(){
 int MultiClefInstrument::getNum(){
     return num_;
 }
-
-// void MultiClefInstrument::makePart(std::string filename){
-//     string fileContents = "\\version \"2.24.1\"\n\\language \"english\"\n\n";
-//     fileContents += "\\include \"definitions.ily\"\n\n";
-//     fileContents += "\\score {\n";
-//     fileContents += scoreBox();
-//     fileContents += "}\n";
-//     std::ofstream out(filename);
-//     out << fileContents << endl;
-// }

--- a/src/pianoharp.cpp
+++ b/src/pianoharp.cpp
@@ -4,8 +4,8 @@
 using namespace std;
 
 Piano::Piano(InstrumentData data, vector<Row> RHrows,vector<Row> LHrows, vector<short> dynamics, int num, BoulezData boulez) : 
-    MultiClefInstrument(data, boulez, {RHrows, LHrows, dynamics, "Piano", "piano", num}, {Note("a", -3), Note("c", 4)}) {};
+    MultiClefInstrument(data, boulez, {RHrows, LHrows, dynamics, "Piano", "piano", "pno", num}, {Note("a", -3), Note("c", 4)}) {};
 
 Harp::Harp(InstrumentData data, vector<Row> RHrows,vector<Row> LHrows, vector<short> dynamics,int num, BoulezData boulez) : 
-    MultiClefInstrument(data, boulez, {RHrows, LHrows, dynamics, "Harp", "harp", num},{Note("c", -3), Note("g",3)}) {};
+    MultiClefInstrument(data, boulez, {RHrows, LHrows, dynamics, "Harp", "harp", "arp", num},{Note("c", -3), Note("g",3)}) {};
 

--- a/src/serialismGenerator.cpp
+++ b/src/serialismGenerator.cpp
@@ -303,17 +303,19 @@ std::string SerialismGenerator::definitionHeader() const{
 }
 
 std::string SerialismGenerator::scoreBox() {
-    std::string scoreBox = "\\version \"2.24.3\"\n";
+    std::string scoreBox;
     if (parts_){
-        scoreBox += "\\include \"definitions.ily\"\n\n";
         scoreBox += header();
+        scoreBox += "\\include \"definitions.ily\"\n\n";
     }
-    scoreBox += "\\score {\n\t<<";
+    scoreBox += "\\score {\n\t\\new StaffGroup\n\t<<";
 
     for (shared_ptr<Instrument>& instrument : instruments_){
-        scoreBox += instrument->instrumentScoreBox();
+        scoreBox += instrument->instrumentScoreBox(false);
     }
-    scoreBox += "\n\t>>\n}";
+    scoreBox += "\n\t>>\n";
+    scoreBox += "\t\\layout {\n\tindent = 2 \\cm\n\tshort-indent = 1\\cm\n\t}";
+    scoreBox += "\n}";
     return scoreBox;
 }
 

--- a/src/singleClef.cpp
+++ b/src/singleClef.cpp
@@ -48,7 +48,7 @@ std::string SingleClefInstrument::staffHeader() {
     return header;
 }
 
-std::string SingleClefInstrument::scoreBox() {
+std::string SingleClefInstrument::instrumentScoreBox() {
     string num = to_string(num_);
     string scoreBox = "\n\t\\new Staff \\with {instrumentName = \"";
     scoreBox += displayName_ +" " +  to_string(num_) + "\" } { \\" + variableName_+ " }";
@@ -63,12 +63,12 @@ int SingleClefInstrument::getNum(){
     return num_;
 }
 
-void SingleClefInstrument::makePart(std::string filename){
-    string fileContents = "\\version \"2.24.1\"\n\\language \"english\"\n\n";
-    fileContents += "\\include \"definitions.ily\"\n\n";
-    fileContents += "\\score {\n";
-    fileContents += scoreBox();
-    fileContents += "}\n";
-    std::ofstream out(filename);
-    out << fileContents << endl;
-}
+// void SingleClefInstrument::makePart(std::string filename){
+//     string fileContents = "\\version \"2.24.1\"\n\\language \"english\"\n\n";
+//     fileContents += "\\include \"definitions.ily\"\n\n";
+//     fileContents += "\\score {\n";
+//     fileContents += scoreBox();
+//     fileContents += "}\n";
+//     std::ofstream out(filename);
+//     out << fileContents << endl;
+// }

--- a/src/singleClef.cpp
+++ b/src/singleClef.cpp
@@ -6,6 +6,7 @@ SingleClefInstrument::SingleClefInstrument(InstrumentData data, BoulezData boule
                     rows_{SCdata.rows_},
                     displayName_{SCdata.displayName_}, 
                     variableName_{SCdata.variableName_}, 
+                    shortName_{SCdata.shortName_},
                     dynamicsRow_{SCdata.dynamicsRow_},
                     clef_{SCdata.clef_}, 
                     octave_{SCdata.octave_},
@@ -48,10 +49,15 @@ std::string SingleClefInstrument::staffHeader() {
     return header;
 }
 
-std::string SingleClefInstrument::instrumentScoreBox() {
+std::string SingleClefInstrument::instrumentScoreBox(bool specificPart) {
     string num = to_string(num_);
     string scoreBox = "\n\t\\new Staff \\with {instrumentName = \"";
-    scoreBox += displayName_ +" " +  to_string(num_) + "\" } { \\" + variableName_+ " }";
+    scoreBox += displayName_ + " " + to_string(num_) + "\"";
+    if (!specificPart){ // If not in a specific part, add short instrument name
+        scoreBox += " shortInstrumentName = \"" + shortName_ + " " + to_string(num_) + "\"";
+    }
+    scoreBox += "} { \\" + variableName_ + " }";
+
     return scoreBox;
 }
 
@@ -62,13 +68,3 @@ std::string SingleClefInstrument::getName(){
 int SingleClefInstrument::getNum(){
     return num_;
 }
-
-// void SingleClefInstrument::makePart(std::string filename){
-//     string fileContents = "\\version \"2.24.1\"\n\\language \"english\"\n\n";
-//     fileContents += "\\include \"definitions.ily\"\n\n";
-//     fileContents += "\\score {\n";
-//     fileContents += scoreBox();
-//     fileContents += "}\n";
-//     std::ofstream out(filename);
-//     out << fileContents << endl;
-// }


### PR DESCRIPTION
Improved Instrument names and score appearance: 
1. Added a "short name" abbreviation to the score 
2. Adjusted margins so that long names like "French Horn" and "String Bass" won't go off the page
3. Added a header to the top of each score to have the title, composer and the correct part name
4. Added a StaffGroup to the score to unify it as one group not a collection of parts. 